### PR TITLE
Removed sender from SubClass example

### DIFF
--- a/Player-Commands.md
+++ b/Player-Commands.md
@@ -53,7 +53,7 @@ class MyPlayer : BasePlayer
     private void HelloWorldCommand(int times)
     {
         for(var i = 0; i < times; i++)
-            sender.SendClientMessage("Hello, world!");
+            SendClientMessage("Hello, world!");
     }
 }
 ```


### PR DESCRIPTION
It's undefined there and shoudn't be used cause of non-static method.