### PR TITLE
General improvements/additions

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -26,7 +26,7 @@ with a text editor.
 
 As of SampSharp 0.8:
 - Add a `coreclr` value which points to the dotnet runtime path.
-- Add a `gamemode` value which points to your gamemode dll path.
+- Add a `gamemode` value which points to your gamemode dll path. (see ["Publishing the project"](starting-development#publishing-the-project))
 
 ```
 echo Executing Server Config...

--- a/Setup.md
+++ b/Setup.md
@@ -21,8 +21,12 @@ with a text editor.
 
 - Add `plugins SampSharp` to the file
 - Change the `rcon_password` to a secure long password
-- Change `gamemode` to `empty 1`
+- Change `gamemode0` to `empty 1`
 - Remove the `filterscripts` value
+
+As of SampSharp 0.8:
+- Add a `coreclr` value which points to the dotnet runtime path.
+- Add a `gamemode` value which points to your gamemode dll path.
 
 ```
 echo Executing Server Config...
@@ -32,6 +36,8 @@ maxplayers 50
 port 7777
 hostname SA-MP 0.3 Server
 gamemode0 empty 1
+gamemode path/to/your/Gamemode.dll
+coreclr path/to/downloaded/dotnet-runtime/
 announce 0
 chatlogging 0
 weburl www.sa-mp.com
@@ -44,6 +50,21 @@ maxnpc 0
 logtimeformat [%H:%M:%S]
 language English
 plugins SampSharp
+```
+
+Dotnet runtime
+----------------
+The dotnet runtime package can be downloaded from the [Microsoft website for windows](https://www.microsoft.com/net/download/thank-you/dotnet-runtime-2.1.1-windows-x86-binaries) or in case of linux there's a unofficial runtime located [here](https://deploy.timpotze.nl/packages/dotnet20180628.zip) ([refs issue #25](https://github.com/SampSharp/docs/issues/25)).
+
+For Windows the value in the server config should look something like:
+```
+corclr path/to/downloaded/dotnet-runtime-2.1.1-win-x86/shared/Microsoft.NETCore.App/2.1.1
+```
+
+for the unofficial linux dotnet runtime:
+
+```
+coreclr path/to/downloaded/dotnet-runtime/
 ```
 
 SampSharp Plugin

--- a/Starting-Development.md
+++ b/Starting-Development.md
@@ -85,11 +85,9 @@ private static void Main(string[] args)
 
 Publishing the project
 ----------------------
-After every change in the newly created project, you need to publish the project to have your gamemode `.dll` file and the dependencies.
+After every change in the newly created project, you need to (build and) publish the project to have your gamemode `.dll` file and the dependencies.
 
 1. Click on `Build > Publish x` (where x is your project name).
 1. Select so it publishes to a folder and provide a path.
 1. Click `Publish`
-1. Edit `gamemode` entry in the server config which points to the gamemode dll in the publish folder.
-
-Afterwards in the provided folder your gamemode dll is located together with the dependencies dll's.
+1. Edit `gamemode` entry in the server config which points to the generated gamemode `.dll` in the provided publish folder.

--- a/Starting-Development.md
+++ b/Starting-Development.md
@@ -82,3 +82,14 @@ private static void Main(string[] args)
         .Run();
 }
 ```
+
+Publishing the project
+----------------------
+After every change in the newly created project, you need to publish the project to have your gamemode `.dll` file and the dependencies.
+
+1. Click on `Build > Publish x` (where x is your project name).
+1. Select so it publishes to a folder and provide a path.
+1. Click `Publish`
+1. Edit `gamemode` entry in the server config which points to the gamemode dll in the publish folder.
+
+Afterwards in the provided folder your gamemode dll is located together with the dependencies dll's.

--- a/Starting-Development.md
+++ b/Starting-Development.md
@@ -23,10 +23,10 @@ Referencing the Framework
 To be able to interact with the server, you need to add the framework to your
 project's references.
 
-1. In the Solution explorer, right click on References under your project.
+1. In the Solution explorer, right click on `Dependencies`under your project.
 1. Click on `Manage NuGet Packages...`.
-1. Under `Online` select the SampSharp repository.
-1. Click on `Framework for SA-MP#` and click on Install.
+1. Under `Package source` select the SampSharp repository.
+1. Click on any `SampSharp.*` package and click on Install.
 
 Defining the Entry Point
 ------------------------

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -2,15 +2,15 @@ Getting Started
 ---------------
 - [Introduction](introduction)
 - [Setup](setup)
-- [Starting Development](starting-development) [TODO]
-- [Configuration](configuration) [TODO]
+- [Starting Development](starting-development)
+- [Configuration](configuration)
 <!-- [Upgrade Guide](upgrade-guide) [TODO] -->
 
 Basics
 ------
 - [GameMode Builder](gamemode-builder)
 - [GameMode](gamemode)
-- [Players](players) [TODO]
+- [Players](players)
 - [NPCs](npcs) [TODO]
 - [Vehicles](vehicles) [TODO]
 - [Actors](actors) [TODO]
@@ -28,7 +28,7 @@ Basics
 Advanced
 --------
 - [Intermissions](intermissions) [TODO]
-- [Interacting with Plugins](interacting-with-plugins)
+- [Interacting with Plugins](interacting-with-plugins) [TODO]
 - [Callbacks](callbacks) (TODO: Move to interacting-with-plugins)
 - [Natives](natives) (TODO: Move to interacting-with-plugins)
 - [Extensions](extensions)
@@ -37,7 +37,7 @@ Advanced
 
 Developer Resources
 -------------------
-- [Building the Plugin](building-the-plugin) [TODO]
+- [Building the Plugin](building-the-plugin)
 - [SampSharp protocol](sampsharp-protocol) [TODO]
 
 Miscellaneous 

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -11,6 +11,7 @@ Basics
 - [GameMode Builder](gamemode-builder)
 - [GameMode](gamemode)
 - [Players](players)
+- [Timers](timers) [TODO]
 - [NPCs](npcs) [TODO]
 - [Vehicles](vehicles) [TODO]
 - [Actors](actors) [TODO]


### PR DESCRIPTION
* Adds a `Dotnet runtime` section on setup page
* Adds a `Publishing the project` section on "Starting development" page
* Changed `samp server` section a bit with 0.8 changes
* Changed `referencing the framework`a bit for .net core / visual studio 2019
* Removed some "[todo]" tags in the sidebar as those pages are kinda completed already. At first i didn't click on them because i thought they were empty.
